### PR TITLE
Add first draft of waveform standard operating procedure

### DIFF
--- a/sop-website/docs/Waveform-Data/Waveform-Data.mdx
+++ b/sop-website/docs/Waveform-Data/Waveform-Data.mdx
@@ -67,7 +67,7 @@ This SOP applies to all hospitals participating in the CHoRUS project and covers
 
 ### 5.3. Validation and Feedback
 
-- The CHoRUS Waveform Working Group will review all submitted data for:
+- CHoRUS Central will review all submitted data for:
   - Compliance with WFDB format or documentation of alternative formats.
   - Completeness and consistency.
 - Hospitals will be notified of any issues or required corrections.

--- a/sop-website/docs/Waveform-Data/Waveform-Data.mdx
+++ b/sop-website/docs/Waveform-Data/Waveform-Data.mdx
@@ -62,8 +62,6 @@ This SOP applies to all hospitals participating in the CHoRUS project and covers
 2. **Verify Submission:**
    - Provide a text file named `SUBMISSION.md` with the following details:
      - Hospital name
-     - Data creation date
-     - Version number
      - Brief description of the dataset
      - Any known issues.
 

--- a/sop-website/docs/Waveform-Data/Waveform-Data.mdx
+++ b/sop-website/docs/Waveform-Data/Waveform-Data.mdx
@@ -62,8 +62,8 @@ This SOP applies to all hospitals participating in the CHoRUS project and covers
 2. **Verify Submission:**
    - Provide a text file named `SUBMISSION.md` with the following details:
      - Hospital name
-     - Brief description of the dataset
-     - Any known issues.
+     - Brief description of the dataset (including the types of waveform files being submitted and the number of each type)
+     - Any known issues
 
 ### 5.3. Validation and Feedback
 

--- a/sop-website/docs/Waveform-Data/Waveform-Data.mdx
+++ b/sop-website/docs/Waveform-Data/Waveform-Data.mdx
@@ -1,5 +1,104 @@
 ---
-title: Waveform Data
+title: Contributing waveform data to CHoRUS
 id: Waveform Data
 description:  An SOP for handling various waveform signals
 ---
+
+## 1. Purpose
+
+This Standard Operating Procedure (SOP) outlines the process for hospitals participating in the CHoRUS project to contribute clinical waveform data (e.g., ECG, EEG). The CHoRUS project is a collaborative effort to create a shared research dataset. To ensure consistency and usability, this SOP defines the requirements and procedures for data formatting, documentation, and submission.
+
+---
+
+## 2. Scope
+
+This SOP applies to all hospitals participating in the CHoRUS project and covers the submission of clinical waveform data. All contributors are expected to follow this SOP to facilitate efficient data integration and analysis.
+
+---
+
+## 3. Responsibilities
+
+- **Participating Hospitals:** Ensure data is provided in the specified format or an acceptable alternative, as outlined below.
+- **CHoRUS Waveform Working Group:** Provide support and tools for data conversion, review submitted data for compliance, and maintain a centralized dataset.
+
+---
+
+## 4. Data Format Requirements
+
+### 4.1. Preferred Format: WFDB
+
+- All hospitals are **strongly encouraged** to submit waveform data in the WFDB (WaveForm DataBase) format.
+- WFDB is a widely used and standardized format for storing physiological signals. It ensures compatibility with CHoRUS tools and workflows.
+
+### 4.2. Alternative Formats
+
+- If a hospital cannot convert data to WFDB format, they may submit data in an **alternative format** under the following conditions:
+  1. The alternative format must be **fully documented**, including:
+     - File structure
+     - Signal encoding and metadata
+     - Any proprietary or custom specifications
+  2. Hospitals must provide sufficient information for the CHoRUS Waveform Working Group to perform the conversion to WFDB.
+
+---
+
+## 5. Procedures
+
+### 5.1. Preparing Data
+
+1. **Convert to WFDB (Preferred):**
+   - Use available tools (e.g., `wfdb-python`) to convert clinical waveform data to WFDB format.
+   - Ensure all required files are included:
+     - Signal files (e.g., `.dat`)
+     - Header files (e.g., `.hea`)
+
+2. **Alternative Format Submission:**
+   - If conversion to WFDB is not feasible, ensure the alternative format is documented according to Section 4.2.
+   - Provide accompanying documentation describing the format and tools (if available) for reading the data.
+
+### 5.2. Submitting Data
+
+1. **Upload to CHoRUS Repository:**
+   - Use the secure data submission platform provided by CHoRUS to upload files.
+2. **Verify Submission:**
+   - Provide a text file named `SUBMISSION.md` with the following details:
+     - Hospital name
+     - Data creation date
+     - Version number
+     - Brief description of the dataset
+     - Any known issues.
+
+### 5.3. Validation and Feedback
+
+- The CHoRUS Waveform Working Group will review all submitted data for:
+  - Compliance with WFDB format or documentation of alternative formats.
+  - Completeness and consistency.
+- Hospitals will be notified of any issues or required corrections.
+
+---
+
+## 6. Tools and Resources
+
+- WFDB Conversion Tools:
+  - [WFDB python](https://github.com/MIT-LCP/wfdb-python): WFDB Python package.
+
+---
+
+## 7. Revision History
+
+| Version | Date       | Description                                |
+|---------|------------|--------------------------------------------|
+| 1.0     | 2024-11-21 | Initial version                              |
+
+---
+
+## 8. Contact Information
+
+- **CHoRUS Waveform Working Group**
+  - Email: Brian Gow `<briangow@mit.edu>`
+
+---
+
+## 9. References
+
+- [WFDB Format Documentation](https://wfdb.io/)
+- [NIH CHoRUS Project Overview](https://chorus4ai.org/)


### PR DESCRIPTION
This pull requests adds a standard operating procedure (SOP) for hospitals participating in the CHoRUS project to contribute clinical waveform data (e.g., ECG, EEG).

We plan to follow up with an additional document that describes our expectations in terms of the WFDB file format/structure in detail. 

I have tested the documentation locally and it looks fine. As long as the content makes sense to @briangow I think this is good to merge.