### PR TITLE
Add first draft of WFDB format standard operating procedure

### DIFF
--- a/sop-website/docs/Waveform-Data/waveform-file-format.mdx
+++ b/sop-website/docs/Waveform-Data/waveform-file-format.mdx
@@ -1,0 +1,110 @@
+---
+title: Waveform File Format
+id: Waveform File Format
+description:  An SOP for the waveform file format
+---
+
+## 1. Purpose
+
+This document defines the standard waveform file format for data contributions to the CHoRUS project. The purpose is to ensure consistent formatting of clinical waveform data submitted by participating hospitals. For a high level summary of the process for contributing waveform data to CHoRUS, see the SOP on [contributing waveforms](/Chorus_SOP/docs/Waveform-Data/).
+
+---
+
+## 2. File Structure
+
+All waveform data must adhere to the following directory structure to facilitate ingestion and processing.
+
+### 2.1. Example File Structure
+
+```plaintext
+.
+├── <person_id>                            # Patient-specific subdirectory
+│   └── waveforms
+│       └── <session_number>
+│           ├── <session_number>.hea       # Header file for waveform record <session_number>
+│           └── <session_number>.dat       # Signal file (second segment)
+└── RECORDS                                # List of all record names (one per line)
+```
+
+### 2.2. Explanation of File Structure
+
+- `<person_id>/`:
+  - Root directory for all patient data. Each patient should have a unique identifier (e.g., `10001`).
+- `waveforms/`:
+  - Patients may have multiple types of data. The `waveforms` folder is intended for grouping waveforms.
+  - Inside each patient directory, files are organized by `<session_number>`.
+- `<session_number>/`:
+  - Session number indicates a unique recording for the patient. A single patient (i.e. a single `<person_id>`) may contain multiple sessions.
+- Record files:
+  - Each record consists of one or more:
+    - `.hea` file/s: Metadata and configuration of the waveform record.
+    - `.dat` file/s: Binary signal files, one or more per record.
+
+---
+
+## 3. Header File (.hea) Format
+
+The WFDB `.hea` file is a text file containing metadata about the waveform record. It must follow the WFDB standard header format. Below is an example:
+
+### 3.1. Example Header File: `12345.hea`
+
+```
+12345 2 360 650000
+12345.dat 16 200/μV 8 0 0 1234 0 ECG1
+12345.dat 16 200/μV 8 0 0 1234 0 ECG2
+# Age: 65
+# Sex: Male
+# Diagnosis: Myocardial Infarction
+```
+
+### 3.2. Explanation of Header Content
+
+1. First Line (General Record Info):
+    - `12345`: Record name (must match the filename prefix).
+    - `2`: Number of signals in the record.
+    - `360`: Sampling frequency in Hz.
+    - `650000`: Number of samples per signal.
+
+2. Subsequent Lines (Signal Descriptions):
+    - `12345x.dat`: Filename of the signal file.
+    - `16`: Storage format (16-bit integers).
+    - `200/μV`: ADC gain (e.g., 200 digital units per microvolt).
+    - `8`: ADC resolution (bits).
+    - `0`: ADC zero value.
+    - `0`: Initial value.
+    - `1234`: Checksum (sum of all samples modulo 2^16).
+    - `0`: Block size.
+    - `ECG1`: Signal label (e.g., lead name).
+
+3. Comments (Optional):
+    - Lines starting with `#` contain additional metadata, such as patient demographics and clinical information.
+    - We discourage use of comments. Instead, metadata should be captured in the associated structured EHR data contribution.
+
+---
+
+## 4. Tools and Resources
+
+- WFDB Conversion Tools:
+  - [WFDB python](https://github.com/MIT-LCP/wfdb-python): WFDB Python package.
+
+---
+
+## 5. Revision History
+
+| Version | Date       | Description                                |
+|---------|------------|--------------------------------------------|
+| 1.0     | 2024-11-21 | Initial version                              |
+
+---
+
+## 6. Contact Information
+
+- **CHoRUS Waveform Working Group**
+  - Email: Brian Gow `<briangow@mit.edu>`
+
+---
+
+## 7. References
+
+- [WFDB Format Documentation](https://wfdb.io/)
+- [NIH CHoRUS Project Overview](https://chorus4ai.org/)

--- a/sop-website/docs/Waveform-Data/waveform-file-format.mdx
+++ b/sop-website/docs/Waveform-Data/waveform-file-format.mdx
@@ -35,10 +35,15 @@ All waveform data must adhere to the following directory structure to facilitate
   - Inside each patient directory, files are organized by `<session_number>`.
 - `<session_number>/`:
   - Session number indicates a unique recording for the patient. A single patient (i.e. a single `<person_id>`) may contain multiple sessions.
+
+Submissions in WFDB format:
 - Record files:
   - Each record consists of one or more:
     - `.hea` file/s: Metadata and configuration of the waveform record.
     - `.dat` file/s: Binary signal files, one or more per record.
+
+Submissions not in WFDB format:
+- Should follow the naming structure outlined above but stored in the format being provided (e.g. hdf5)
 
 ---
 
@@ -92,14 +97,16 @@ The WFDB `.hea` file is a text file containing metadata about the waveform recor
 ## 5. Preparing Waveforms
 The WFDB python toolbox will handle writing the `.hea` and `.dat` files once the required information is provided. 
 
-### 5.1. Segment Definition
+### 5.1. WFDB formatted submissions
+
+### 5.1.1. Segment Definition
 In WFDB, a segment is a continous set of signals. Each segment has a `.hea` file and at least one `.dat` file.
 
-### 5.2. Time Shifting
+### 5.1.2. Time Shifting
 If your EHR, waveform, and imaging data are being date shifted, all data for a given subject must be shifted by the same amount
 of time. See [Multimodal-Linkage](https://chorus-ai.github.io/Chorus_SOP/docs/Multimodal-Linkage/) for more detail.
 
-### 5.2. High Frequency Waveforms
+### 5.1.3. High Frequency Waveforms
 High frequency waveform files (e.g. ECG, EEG) should be saved by writing a WFDB record. A single segment record can be written
 with `wfdb.io.wrsamp`. A multisegment record should be written by creating a `wfdb.io.MultiRecord` and using its `wrsamp` 
 method to save the WFDB file. 
@@ -110,10 +117,21 @@ A new segment should be create if either of these conditions are met:
 a channel's data has disappeared for more than 5 minutes a new segment should be created. However, if it disappears for less
 than 5 minutes, the missing data should be filled with NaNs, and a new segment should not be created. 
 
-### 5.3. Low Frequency Vitals / Numerics
+### 5.2. Low Frequency Vitals / Numerics
 Low frequency signals (e.g. heart rate) should be saved as a CSV file in the same folder as the high frequency waveforms.
 The CSV file should be named as `<session_number>n.csv`. Please do not resample the low frequency signals in an effort to 
 create a uniform time interval. 
+
+### 5.3. Non-WFDB formatted submissions
+As mentioned in [contributing waveforms](/Chorus_SOP/docs/Waveform-Data/), detailed information about submissions not in
+WFDB format need to be provided. This should include the following information in addition to any other relevant information:
+- Explanation for each variable in the submission (e.g. `StartTime` is the time at the start of the first sample in the
+stream)
+- The data type for each variable
+- Units for each variable (as applicable)
+- How the data is encoded
+- Information about how to calculate the sample interval (e.g. `EndTime` - `StartTime` / `# samples`)
+- Indication about whether the sample intervals are uniform for each waveform type and channel.
 
 ---
 

--- a/sop-website/docs/Waveform-Data/waveform-file-format.mdx
+++ b/sop-website/docs/Waveform-Data/waveform-file-format.mdx
@@ -89,7 +89,35 @@ The WFDB `.hea` file is a text file containing metadata about the waveform recor
 
 ---
 
-## 5. Revision History
+## 5. Preparing Waveforms
+The WFDB python toolbox will handle writing the `.hea` and `.dat` files once the required information is provided. 
+
+### 5.1. Segment Definition
+In WFDB, a segment is a continous set of signals. Each segment has a `.hea` file and at least one `.dat` file.
+
+### 5.2. Time Shifting
+If your EHR, waveform, and imaging data are being date shifted, all data for a given subject must be shifted by the same amount
+of time. See [Multimodal-Linkage](https://chorus-ai.github.io/Chorus_SOP/docs/Multimodal-Linkage/) for more detail.
+
+### 5.2. High Frequency Waveforms
+High frequency waveform files (e.g. ECG, EEG) should be saved by writing a WFDB record. A single segment record can be written
+with `wfdb.io.wrsamp`. A multisegment record should be written by creating a `wfdb.io.MultiRecord` and using its `wrsamp` 
+method to save the WFDB file. 
+
+A new segment should be create if either of these conditions are met:
+- The length of the current segment exceeds 8 hours
+- The set of channels in the data changes. In other words if a channel's data stream disappears or a new channel appears. If 
+a channel's data has disappeared for more than 5 minutes a new segment should be created. However, if it disappears for less
+than 5 minutes, the missing data should be filled with NaNs, and a new segment should not be created. 
+
+### 5.3. Low Frequency Vitals / Numerics
+Low frequency signals (e.g. heart rate) should be saved as a CSV file in the same folder as the high frequency waveforms.
+The CSV file should be named as `<session_number>n.csv`. Please do not resample the low frequency signals in an effort to 
+create a uniform time interval. 
+
+---
+
+## 6. Revision History
 
 | Version | Date       | Description                                |
 |---------|------------|--------------------------------------------|
@@ -97,14 +125,14 @@ The WFDB `.hea` file is a text file containing metadata about the waveform recor
 
 ---
 
-## 6. Contact Information
+## 7. Contact Information
 
 - **CHoRUS Waveform Working Group**
   - Email: Brian Gow `<briangow@mit.edu>`
 
 ---
 
-## 7. References
+## 8. References
 
 - [WFDB Format Documentation](https://wfdb.io/)
 - [NIH CHoRUS Project Overview](https://chorus4ai.org/)

--- a/sop-website/docs/Waveform-Data/waveform-file-format.mdx
+++ b/sop-website/docs/Waveform-Data/waveform-file-format.mdx
@@ -94,63 +94,63 @@ The WFDB `.hea` file is a text file containing metadata about the waveform recor
 
 ---
 
-## 5. Preparing Waveforms
-The WFDB python toolbox will handle writing the `.hea` and `.dat` files once the required information is provided. 
+## 5. Preparing Waveforms in the WFDB Format
 
-### 5.1. WFDB formatted submissions
+All hospitals are strongly encouraged to submit waveform data in the WFDB (WaveForm DataBase) format. The WFDB Python toolbox automatically generates the `.hea` and `.dat` file structure when provided with the necessary information.
 
-### 5.1.1. Segment Definition
-In WFDB, a segment is a continous set of signals. Each segment has a `.hea` file and at least one `.dat` file.
+### 5.1. Segment Definition
 
-### 5.1.2. Time Shifting
-If your EHR, waveform, and imaging data are being date shifted, all data for a given subject must be shifted by the same amount
-of time. See [Multimodal-Linkage](https://chorus-ai.github.io/Chorus_SOP/docs/Multimodal-Linkage/) for more detail.
+In WFDB, a segment is a contiguous set of signals. Each segment has a `.hea` file and at least one `.dat` file.
 
-### 5.1.3. High Frequency Waveforms
-High frequency waveform files (e.g. ECG, EEG) should be saved by writing a WFDB record. A single segment record can be written
-with `wfdb.io.wrsamp`. A multisegment record should be written by creating a `wfdb.io.MultiRecord` and using its `wrsamp` 
-method to save the WFDB file. 
+### 5.2. Time Shifting
 
-A new segment should be create if either of these conditions are met:
+If your EHR, waveform, and imaging data are being date-shifted, ensure that all data for a given subject is shifted by the same duration. See [Multimodal-Linkage](https://chorus-ai.github.io/Chorus_SOP/docs/Multimodal-Linkage/) for more detail.
+
+### 5.3. High Frequency Waveforms
+
+High-frequency waveform files (e.g., ECG, EEG) should be saved as WFDB records. Use `wfdb.io.wrsamp` to write a single-segment record. For multisegment records, create a `wfdb.io.MultiRecord` object and use its `wrsamp` method to save the WFDB file.
+
+A new segment should be created if either of the following conditions is met:
+
 - The length of the current segment exceeds 8 hours
-- The set of channels in the data changes. In other words if a channel's data stream disappears or a new channel appears. If 
-a channel's data has disappeared for more than 5 minutes a new segment should be created. However, if it disappears for less
-than 5 minutes, the missing data should be filled with NaNs, and a new segment should not be created. 
+- The set of channels in the data changes. Specifically:
+  - If a channel's data stream disappears or a new channel appears
+  - If a channel's data is missing for more than 5 minutes. For gaps of less than 5 minutes, fill the gap with NaNs
 
-### 5.2. Low Frequency Vitals / Numerics
-Low frequency signals (e.g. heart rate) should be saved as a CSV file in the same folder as the high frequency waveforms.
-The CSV file should be named as `<session_number>n.csv`. Please do not resample the low frequency signals in an effort to 
-create a uniform time interval. 
+### 5.4. Low Frequency Signals ("Numerics")
 
-### 5.3. Non-WFDB formatted submissions
-As mentioned in [contributing waveforms](/Chorus_SOP/docs/Waveform-Data/), detailed information about submissions not in
-WFDB format need to be provided. This should include the following information in addition to any other relevant information:
-- Explanation for each variable in the submission (e.g. `StartTime` is the time at the start of the first sample in the
+Low frequency signals (e.g. heart rate) should be saved as a CSV file in the same folder as the high frequency waveforms. The CSV file should be named as `<session_number>n.csv`. Please do not resample the low frequency signals in an effort to  create a uniform time interval. 
+
+## 6. Preparing Waveforms in an Alternative Format
+
+As discussed in the SOP on [contributing waveforms](/Chorus_SOP/docs/Waveform-Data/), the WFDB format is strongly preferred. If providing an alternative format, detailed documentation about the format is required to facilitate conversion to WFDB. The documentation should include:
+
+- A description of each variable (e.g. `StartTime` represents the time at the start of the first sample in the
 stream)
 - The data type for each variable
-- Units for each variable (as applicable)
-- How the data is encoded
-- Information about how to calculate the sample interval (e.g. `EndTime` - `StartTime` / `# samples`)
-- Indication about whether the sample intervals are uniform for each waveform type and channel.
+- Units of each variable, if applicable
+- Details on how the data is encoded
+- Instructions for calculating the sample interval (e.g. `EndTime - StartTime / # samples`)
+- An indication of whether the sample intervals are uniform accross waveform types and channels.
 
 ---
 
-## 6. Revision History
+## 7. Revision History
 
 | Version | Date       | Description                                |
 |---------|------------|--------------------------------------------|
-| 1.0     | 2024-11-21 | Initial version                              |
+| 1.0     | 2024-11-21 | Initial version                            |
 
 ---
 
-## 7. Contact Information
+## 8. Contact Information
 
 - **CHoRUS Waveform Working Group**
   - Email: Brian Gow `<briangow@mit.edu>`
 
 ---
 
-## 8. References
+## 9. References
 
 - [WFDB Format Documentation](https://wfdb.io/)
 - [NIH CHoRUS Project Overview](https://chorus4ai.org/)


### PR DESCRIPTION
This pull requests adds a standard operating procedure (SOP) that defines our expectations around the WFDB file format. It supplements the information provided in: https://github.com/chorus-ai/Chorus_SOP/pull/34



