### PR TITLE
Defer to the Multimodal Linkage SOP

### DIFF
--- a/sop-website/docs/Waveform-Data/Waveform-Data.mdx
+++ b/sop-website/docs/Waveform-Data/Waveform-Data.mdx
@@ -91,7 +91,7 @@ See the **Submitting Waveforms** section in the SOP on [waveform file format](wa
      - Brief description of the dataset (number of patients, the years covered by your waveform data, the types (e.g. high-frequency telemetry, low-frequency telemetry, EEG) of waveform files being submitted and the number of each type)
      - Any known issues (if there are any known issues with the waveforms, please make them known so we can try to address them)
 3. **Waveform EHR linkage**
-   - Provide a file named `waveform_visit_links.csv` which links waveform files to visits. See [Multimodal-Linkage](https://chorus-ai.github.io/Chorus_SOP/docs/Multimodal-Linkage/) and the **Linking Waveform Sessions to Visits** section in the SOP on [waveform file format](waveform-file-format.mdx) for details
+   - Provide the files requested in the [Multimodal-Linkage SOP](https://chorus-ai.github.io/Chorus_SOP/docs/Multimodal-Linkage/)
 4. **Code Submission:**
    - Mapping file (required): submit a mapping file for telemetry waveforms and EEG waveforms (if applicable) under the `Metadata` folder. See the **Submitting Waveforms** section in the SOP on [waveform file format](waveform-file-format.mdx) for details.
    - Conversion code: please submit any code you used to convert or deidentify your waveform data to the [CHoRUS to WFDB converter repo](https://github.com/chorus-ai/chorus_waveform_conversion). Provide all code under `converters/<site>/` 

--- a/sop-website/docs/Waveform-Data/waveform-file-format.mdx
+++ b/sop-website/docs/Waveform-Data/waveform-file-format.mdx
@@ -20,8 +20,7 @@ All waveform data must adhere to the following directory structure to facilitate
 |  ├── READINESS.md                         # Checklist to indicate that SOP requirements have been met
 |  ├── SUBMISSION.md                        # File outlining details of your submission
 |  ├── Telemetry_mapping.csv                # Mapping file for telemetry waveforms
-|  ├── EEG_mapping.csv                      # Mapping file for EEG waveforms (if applicable)
-|  └── waveform_visit_links.csv             # File linking visit occurrence and waveform session (optional duplicate)
+|  └── EEG_mapping.csv                      # Mapping file for EEG waveforms (if applicable)
 └── <person_id>                             # Patient-specific subdirectory
    └── Waveforms                            # "Waveforms" folder
        ├── Telemetry                        # Folder for telemetry waveforms
@@ -147,9 +146,7 @@ Submit your mapping file(s) under the `Metadata` folder as depicted above.
 
 ## 5. Linking Waveform Sessions to Visits
 
-A table named `waveform_visit_links.csv` should be provided under the `Metadata` folder. This table should have a column for `visit_occurrence_id`, `visit_detail_id`, and `session_id`. If the data collection system does not provide a direct linkage between `session_id` and `visit_occurrence_id`, it may be necessary to infer this linkage based on the start and end time of the session but this should only be done as a last resort. Keep in mind that the session start and end may not exactly match the admission, discharge, or transfer time in the EHR. See [Multimodal-Linkage](https://chorus-ai.github.io/Chorus_SOP/docs/Multimodal-Linkage/) for more detail.
-
-Please outline the process you used for linking `session_id` to `visit_detail_id` in your `SUBMISSION.md` file.
+The [Multimodal-Linkage SOP](https://chorus-ai.github.io/Chorus_SOP/docs/Multimodal-Linkage/) provides details on linking waveform sessions to visits. Please outline the process you used for linking waveform data to visits in your `SUBMISSION.md` file.
 
 ---
 


### PR DESCRIPTION
Sites need to submit information linking their waveform files/sessions to visits in OMOP. The messaging between the Waveform SOP and the [Multimodal-Linkage SOP](https://chorus-ai.github.io/Chorus_SOP/docs/Multimodal-Linkage/) was not consistent. This PR updates the Waveform SOP to suggest using the Multimodal-Linkage SOP for delivering this information. 